### PR TITLE
Add namespace into job_execution_str

### DIFF
--- a/flink-ai-flow/ai_flow/plugin_interface/scheduler_interface.py
+++ b/flink-ai-flow/ai_flow/plugin_interface/scheduler_interface.py
@@ -214,7 +214,8 @@ class JobExecutionInfo(json_utils.Jsonable):
     def generate_execution_str(self):
         if self.workflow_execution is None or self.workflow_execution.workflow_info is None:
             return None
-        return '_'.join([self.workflow_execution.workflow_info.workflow_name,
+        return '_'.join([self.workflow_execution.workflow_info.namespace,
+                         self.workflow_execution.workflow_info.workflow_name,
                          self.workflow_execution.workflow_execution_id,
                          self.job_name,
                          self.job_execution_id])

--- a/flink-ai-flow/ai_flow/test/scheduler/test_scheduler_service.py
+++ b/flink-ai-flow/ai_flow/test/scheduler/test_scheduler_service.py
@@ -114,10 +114,10 @@ class TestSchedulerService(unittest.TestCase):
         workflow_execution_info = WorkflowExecutionInfo(workflow_execution_id='workflow_execution_id',
                                                         workflow_info=workflow_info)
         job_execution_info = JobExecutionInfo(job_name='job_name',
-                                              state='running',
+                                              status='running',
                                               workflow_execution=workflow_execution_info,
                                               job_execution_id='job_execution_id')
-        self.assertEqual('workflow_name_workflow_execution_id_job_name_job_execution_id',
+        self.assertEqual('project_workflow_name_workflow_execution_id_job_name_job_execution_id',
                          job_execution_info.generate_execution_str())
 
     def test_delete_none_workflow(self):


### PR DESCRIPTION
<!--

*Thank you very much for contributing to flink-ai-extended. To help the community review your issue or contribution in the best possible way，please take a few minutes to fulfill following items.*

-->

## What is the purpose of the change

*(For example: This pull request makes user can stop workflow externally.)*


## Brief change log

*(for example:)*
  - *Send StopDagEvent to Airflow scheduler via notification service*
  - *Once received StopDagEvent, Airflow scheduler kills all running dag runs*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests.